### PR TITLE
Add API routes

### DIFF
--- a/packages/server-cli-only/examples/next-js-app/src/app/api/edge/route.ts
+++ b/packages/server-cli-only/examples/next-js-app/src/app/api/edge/route.ts
@@ -1,0 +1,20 @@
+import { getSomeServerCliOnlyData } from "@/data";
+import { NextResponse, type NextRequest } from "next/server";
+
+export const runtime = "edge";
+export const dynamic = "force-dynamic";
+
+/**
+ * @see http://localhost:3000/api/edge
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const data = await getSomeServerCliOnlyData(); // This is a server cli only function
+    return NextResponse.json({ status: 200, timestamp: Date.now(), data});
+  } catch (e: unknown) {
+    return NextResponse.json(
+      { e, status: 500, timestamp: Date.now() },
+      { status: 500 },
+    );
+  }
+}

--- a/packages/server-cli-only/examples/next-js-app/src/app/api/route.ts
+++ b/packages/server-cli-only/examples/next-js-app/src/app/api/route.ts
@@ -1,0 +1,19 @@
+import { getSomeServerCliOnlyData } from "@/data";
+import { NextResponse, type NextRequest } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * @see http://localhost:3000/api
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const data = await getSomeServerCliOnlyData(); // This is a server cli only function
+    return NextResponse.json({ status: 200, timestamp: Date.now(), data});
+  } catch (e: unknown) {
+    return NextResponse.json(
+      { e, status: 500, timestamp: Date.now() },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
@4lm  I've recreated the issue i reported in https://github.com/destacks/core-ts/issues/1. 
I have realized that I haven't reported it correctly, sorry about that!

The issue is only when the entrypoint is a page or an API route that gets served on edge runtime, combined with being used with `--turbo`.

I have added two API routes.

[NodeJS API route](http://localhost:3000/api)
[Edge API route](http://localhost:3000/api/edge)

I have tested and can confirm that this works in production, once deployed to Vercel. But, seeing as Vercel openly plans to use turbo in production later this year, it might be wise for us to find out exactly how to open an issue on the vercel/turbo repository. Honestly I have no idea what to write or how to debug this. I suppose if I knew how to run the package locally, i could console log exactly which if statement is failing, and then report that.